### PR TITLE
Subject

### DIFF
--- a/tutor/apps.py
+++ b/tutor/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class TutorConfig(AppConfig):
     name = 'tutor'
     verbose_name = 'Courses'
+
+    def ready(self):
+        from tutor import signals

--- a/tutor/models.py
+++ b/tutor/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import User
-from django import forms
 from spirit.category.models import Category
+
 
 class Student(models.Model):
     """
@@ -37,25 +37,35 @@ class Subject(models.Model):
     name = models.CharField(
         max_length=50,
         help_text="Full name of the subject (i.e. Humanities)")
-        # below we are creating a one-to-one relationship between Subjects and Categories, so that the forum is structured
-        # around Reed's departments, not arbitrary categories.
-    category = models.OneToOneField(Category, on_delete=models.CASCADE, null=True, blank=True, editable = False)
+    # below we are creating a one-to-one relationship between Subjects and Categories, so that the forum is structured
+    # around Reed's departments, not arbitrary categories.
+    category = models.OneToOneField(Category, on_delete=models.CASCADE,
+                                    null=True, blank=True, editable=False)
+
     def save(self, *args, **kwargs):
+        # Validate abbreviation and name
         for field_name in ['abbreviation', 'name']:
             val = getattr(self, field_name, False)
             if field_name == 'abbreviation':
                 setattr(self, 'abbreviation', val.upper())
             elif field_name == 'name':
                 setattr(self, 'name', val.capitalize())
+
+        # Set up category for subject
         cat = Category.objects.create(title=self.name)
         cat.save()
         self.category = cat
 
         super(Subject, self).save(*args, **kwargs)
 
+    def delete(self, *args, **kwargs):
+        # delete category when deleting subject
+        if self.category:
+            self.category.delete()
+        super(Subject, self).delete(*args, **kwargs)
+
     def __str__(self):
         return self.name
-
 
 
 class Course(models.Model):

--- a/tutor/models.py
+++ b/tutor/models.py
@@ -58,12 +58,6 @@ class Subject(models.Model):
 
         super(Subject, self).save(*args, **kwargs)
 
-    def delete(self, *args, **kwargs):
-        # delete category when deleting subject
-        if self.category:
-            self.category.delete()
-        super(Subject, self).delete(*args, **kwargs)
-
     def __str__(self):
         return self.name
 

--- a/tutor/signals.py
+++ b/tutor/signals.py
@@ -1,0 +1,19 @@
+"""
+File for receiver functions.
+You can read more about what those are here:
+https://docs.djangoproject.com/en/1.11/topics/signals/
+"""
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+import tutor.models as models
+
+
+@receiver(post_delete, sender=models.Subject)
+def delete_category(sender, **kwargs):
+    """
+    deletes the category that has a one-to-one relationship with
+    a given subject when deleting that subject
+    """
+    sub = kwargs.get("instance")
+    if sub.category:
+        sub.category.delete()

--- a/tutor/tests/test_models.py
+++ b/tutor/tests/test_models.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 import random
 
 import tutor.models as models
+from spirit.category.models import Category
 
 
 class CourseTestCase(TestCase):
@@ -49,6 +50,29 @@ class SubjectTestCase(TestCase):
         hum = models.Subject.objects.get(abbreviation="HUM", name="Humanities")
         self.assertTrue((hum.name in hum.__str__())
                         or (hum.abbreviation in hum.__str__()))
+
+    def test_subject_delete_deletes_category_as_well(self):
+        """
+        This tests that when you delete a subject it deletes the
+        category associated with that subject
+        """
+        lit = models.Subject.objects.create(
+            abbreviation="LIT", name="Literature")
+        cat_id = lit.category.id
+        lit.delete()
+        self.assertFalse(Category.objects.filter(id=cat_id).exists())
+
+    def test_subject_queryset_delete_deletes_category(self):
+        """
+        Same as the above test but does a queryset delete. This is
+        important because the admin interface uses queryset deletes
+        """
+        lit = models.Subject.objects.create(
+            abbreviation="LIT", name="Literature")
+        cat_id = lit.category.id
+        subs = models.Subject.objects.filter(id=lit.id)
+        subs.delete()
+        self.assertFalse(Category.objects.filter(id=cat_id).exists())
 
 
 class StudentTestCase(TestCase):


### PR DESCRIPTION
Closes #77 
I made a function that deletes the category that is in a one-to-one realtionship with a given subject after the subject is deleted.
w.r.t. #77, I did not make a function that works the other way because the `on_delete=CASCADE` option on `Subject.category` ensures that when the category gets deleted, the subject does too. However, this does not matter since spirit has no option to delete categories. 