### PR TITLE
Removed banner gap

### DIFF
--- a/tutor/static/css/base.css
+++ b/tutor/static/css/base.css
@@ -4,6 +4,7 @@
 
 html {
     font-size: 20px; /* this specifies that 1rem = 20px, so keep that in mind */
+    overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
Apparently safari ignores `overflow-x: hidden` attributes on body if it isn't also applied to html