### PR TITLE
Made the timestamp use local time

### DIFF
--- a/tutor/templates/django_private_chat/dialogs.html
+++ b/tutor/templates/django_private_chat/dialogs.html
@@ -37,7 +37,7 @@
                                     {{ msg.text}}
                                 {% endautoescape %}
                                 <span class="timestamp">&ndash; <span
-                                        data-livestamp="{{ msg.get_formatted_create_datetime }}">{{ msg.get_formatted_create_datetime }}</span></span>
+                                        data-livestamp="{{ msg.created }}">{{ msg.created }}</span></span>
                             </p>
                         </div>
                     {% endfor %}


### PR DESCRIPTION
There's still bugs with how dialogs.js loads the date time object initially