### PR TITLE
Tutorchat

### DIFF
--- a/tutor/static/css/tutorchat.css
+++ b/tutor/static/css/tutorchat.css
@@ -8,7 +8,6 @@
     color: black;
     background-color: rgba(225, 225, 225, 0.2);
     border-radius: 0.1rem;
-    padding: 5% 0%;
     text-align: center;
     overflow: hidden;
     border: 1rem;
@@ -19,12 +18,16 @@
     text-align: left;
     width: 100%;
     table-layout:fixed;
+    margin-bottom: 0rem;
 }
 
 .messages-table tbody, tr {
     width: 100%;
 }
 
+.messages-table tbody, td {
+    border-top: 0px !important;
+}
 
 .name-cell {
     width: 8rem;

--- a/tutor/static/css/tutorchat.css
+++ b/tutor/static/css/tutorchat.css
@@ -39,3 +39,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* mobile stuff */
+@media screen and (max-width: 740px) {
+    .messages-table {
+        font-size: 0.85rem;
+    }
+}

--- a/tutor/templates/tutor/tutorchat.html
+++ b/tutor/templates/tutor/tutorchat.html
@@ -15,7 +15,7 @@
     <div class="container">
         <h2>Tutoring page</h2>
         <div class="messages-div">
-            <table class="table table-hover messages-table">
+            <table class="messages-table table table-hover">
                 <tbody id="new-message-div">
                     
                 </tbody>
@@ -34,6 +34,7 @@
                             </tr>
                             {% endwith %}
                     {% endfor %}
+                    <tr></tr>
                 </tbody>
             </table>
         </div>

--- a/tutor/templates/tutor/tutorchat.html
+++ b/tutor/templates/tutor/tutorchat.html
@@ -27,7 +27,7 @@
                             <tr id="{{username}}-element" class="clickable-row" data-href='{% url "dialogs_detail" username %}'>
                                 <td class="name-cell"><b>{{username|get_name}}</b></td>
                                 <td class="message-cell">
-                                    {% with dialog|most_recent_message as message %}
+                                    {% with dialog|most_recent_message:request.user.username as message %}
                                         {{ message.text }}
                                     {% endwith %}
                                 </td>

--- a/tutor/templatetags/tutor_extras.py
+++ b/tutor/templatetags/tutor_extras.py
@@ -69,9 +69,16 @@ def get_user(user_name):
 
 
 @register.filter
-def most_recent_message(dialog):
+def most_recent_message(dialog, not_user_name=None):
     """
     Takes a dialog and returns the most recent message in that
     dialog
+    if not_user_name is set, then it looks for the most recent
+    message made by someone other than the user with the
+    given user name
     """
-    return dialog.messages.order_by("-created").first()
+    messages = dialog.messages
+    if not_user_name:
+        user = User.objects.get(username=not_user_name)
+        messages = messages.exclude(sender=user)
+    return messages.order_by("-created").first()


### PR DESCRIPTION
Closes #166 
Sorry I'm making two prs for this, I didn't realize that I would be done so soon.

Here's what the page looks like now:
![image](https://user-images.githubusercontent.com/7049313/28339598-70de6c42-6bc1-11e7-8a9f-a9dce8717361.png)

What you can't see is that each row is a link to the chat page and it gets highlighted when you hover over it and the cursor changes to the hand icon. 