### PR TITLE
Online/Offline status for tutors page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-djconfig==0.5.3
 django-haystack==2.5.1
 django-infinite-scroll-pagination==0.2.0
 django-model-utils==3.0.0
-django-private-chat==0.1.6
+-e git://github.com/grantal/django-private-chat.git#egg=django-private-chat
 django-twitter-bootstrap==3.3.0
 mistune==0.7.1
 olefile==0.44

--- a/tutor/static/css/tutors.css
+++ b/tutor/static/css/tutors.css
@@ -89,3 +89,23 @@ td .tutorlink:hover {
         padding: 0;
     }
 }
+
+/* online/offline circles */
+.on-off-cell {
+    /* cell containing the circle */
+    vertical-align:middle !important;
+}
+
+.circle {
+    border-radius: 50%;
+    width: 10px;
+    height: 10px; 
+}
+
+.online {
+    background-color: green;
+}
+
+.offline {
+    background-color: red;
+}

--- a/tutor/static/js/tutors.js
+++ b/tutor/static/js/tutors.js
@@ -1,5 +1,8 @@
-
 $(document).ready(() => {
+  /* global usersCheckList:false */
+
+  const opponentUsername = '';
+
   let websocket = null;
 
   function setUserOnlineOffline(username, online) {
@@ -12,12 +15,16 @@ $(document).ready(() => {
   }
 
   function setupChatWebSocket() {
-    websocket = new WebSocket(`${baseWsServerPath + sessionKey}/`);
+    websocket = new WebSocket(`${baseWsServerPath + sessionKey}/${opponentUsername}`);
 
     websocket.onopen = function websocketOpen() {
       const onOnlineCheckPacket = JSON.stringify({
         type: 'list-check-online',
         session_key: sessionKey,
+        // Send the users we want to check the status of
+        users_list: usersCheckList,
+        // need opponentUsername in order to get this websocket
+        username: opponentUsername,
       });
       websocket.send(onOnlineCheckPacket);
     };
@@ -41,6 +48,7 @@ $(document).ready(() => {
           for (let i = 0; i < packet.usernames.length; i += 1) {
             setUserOnlineOffline(packet.usernames[i], true);
           }
+          console.log(packet);
           break;
         case 'gone-offline':
           setUserOnlineOffline(packet.username, false);

--- a/tutor/static/js/tutors.js
+++ b/tutor/static/js/tutors.js
@@ -1,0 +1,71 @@
+
+$(document).ready(() => {
+  let websocket = null;
+
+  function setUserOnlineOffline(username, online) {
+    const elem = $(`#user-${username}`);
+    if (online) {
+      elem.attr('class', 'btn btn-success');
+    } else {
+      elem.attr('class', 'btn btn-danger');
+    }
+  }
+
+  function setupChatWebSocket() {
+    const opponentUsername = getOpponnentUsername();
+    websocket = new WebSocket(`${baseWsServerPath + sessionKey}/${opponentUsername}`);
+
+    websocket.onopen = function websocketOpen() {
+      const onOnlineCheckPacket = JSON.stringify({
+        type: 'check-online',
+        session_key: sessionKey,
+        username: opponentUsername,
+                // Sending username because the user needs to know if his opponent is online
+      });
+      const onConnectPacket = JSON.stringify({
+        type: 'online',
+        session_key: sessionKey,
+
+      });
+
+      websocket.send(onConnectPacket);
+      websocket.send(onOnlineCheckPacket);
+    };
+
+
+    window.onbeforeunload = function websocketClose() {
+      const onClosePacket = JSON.stringify({
+        type: 'offline',
+        session_key: sessionKey,
+        username: opponentUsername,
+        // Sending username because to let opponnent know that the user went offline
+      });
+      websocket.send(onClosePacket);
+      websocket.close();
+    };
+
+
+    websocket.onmessage = function websocketMessage(event) {
+      const packet = JSON.parse(event.data);
+
+      switch (packet.type) {
+        case 'new-dialog':
+          break;
+        case 'user-not-found':
+          // TODO: dispay some kind of an error that the user is not found
+          break;
+        case 'gone-online':
+          for (let i = 0; i < packet.usernames.length; i += 1) {
+            setUserOnlineOffline(packet.usernames[i], true);
+          }
+          break;
+        case 'gone-offline':
+          setUserOnlineOffline(packet.username, false);
+          break;
+        default:
+          console.error('error: ', event);
+      }
+    };
+  }
+  setupChatWebSocket();
+});

--- a/tutor/static/js/tutors.js
+++ b/tutor/static/js/tutors.js
@@ -48,7 +48,6 @@ $(document).ready(() => {
           for (let i = 0; i < packet.usernames.length; i += 1) {
             setUserOnlineOffline(packet.usernames[i], true);
           }
-          console.log(packet);
           break;
         case 'gone-offline':
           setUserOnlineOffline(packet.username, false);

--- a/tutor/static/js/tutors.js
+++ b/tutor/static/js/tutors.js
@@ -12,35 +12,18 @@ $(document).ready(() => {
   }
 
   function setupChatWebSocket() {
-    const opponentUsername = getOpponnentUsername();
-    websocket = new WebSocket(`${baseWsServerPath + sessionKey}/${opponentUsername}`);
+    websocket = new WebSocket(`${baseWsServerPath + sessionKey}/`);
 
     websocket.onopen = function websocketOpen() {
       const onOnlineCheckPacket = JSON.stringify({
-        type: 'check-online',
+        type: 'list-check-online',
         session_key: sessionKey,
-        username: opponentUsername,
-                // Sending username because the user needs to know if his opponent is online
       });
-      const onConnectPacket = JSON.stringify({
-        type: 'online',
-        session_key: sessionKey,
-
-      });
-
-      websocket.send(onConnectPacket);
       websocket.send(onOnlineCheckPacket);
     };
 
 
     window.onbeforeunload = function websocketClose() {
-      const onClosePacket = JSON.stringify({
-        type: 'offline',
-        session_key: sessionKey,
-        username: opponentUsername,
-        // Sending username because to let opponnent know that the user went offline
-      });
-      websocket.send(onClosePacket);
       websocket.close();
     };
 

--- a/tutor/static/js/tutors.js
+++ b/tutor/static/js/tutors.js
@@ -8,9 +8,9 @@ $(document).ready(() => {
   function setUserOnlineOffline(username, online) {
     const elem = $(`#user-${username}`);
     if (online) {
-      elem.attr('class', 'btn btn-success');
+      elem.attr('class', 'circle online');
     } else {
-      elem.attr('class', 'btn btn-danger');
+      elem.attr('class', 'circle offline');
     }
   }
 

--- a/tutor/templates/tutor/tutors.html
+++ b/tutor/templates/tutor/tutors.html
@@ -29,6 +29,9 @@
                     </tr>
                 {% for tutor in tutors %}
                     <tr>
+                        <td class="on-off-cell">
+                            <div id="user-{{tutor.user.username}}" class="circle offline"></div> 
+                        </td>
                     {% if tutor.user.first_name or tutor.user.last_name %}
                         <td>
                             {{tutor.user.first_name}}

--- a/tutor/templates/tutor/tutors.html
+++ b/tutor/templates/tutor/tutors.html
@@ -79,3 +79,11 @@
         </div>
     </div>
 {% endblock %}
+
+{% block extra_js %}
+    <script>
+        var baseWsServerPath = "{{ ws_server_path }}";
+        var sessionKey = '{{ request.session.session_key }}'
+    </script>
+    <script src="{% static 'js/tutors.js' %}"></script>
+{% endblock %}

--- a/tutor/templates/tutor/tutors.html
+++ b/tutor/templates/tutor/tutors.html
@@ -83,7 +83,12 @@
 {% block extra_js %}
     <script>
         var baseWsServerPath = "{{ ws_server_path }}";
-        var sessionKey = '{{ request.session.session_key }}'
+        var sessionKey = '{{ request.session.session_key }}';
+        var usersCheckList = [
+          {% for tutor in tutors %}
+              "{{ tutor.user.username }}",
+          {% endfor %}
+        ]
     </script>
     <script src="{% static 'js/tutors.js' %}"></script>
 {% endblock %}

--- a/tutor/views/main.py
+++ b/tutor/views/main.py
@@ -45,11 +45,13 @@ def tutors(request, course_id):
         context
     )
 
+
 def about(request):
     """
     View for the about page. It's a simple webpage with just some text about who the creators of the app are.
     """
     return render(request, 'tutor/about.html')
+
 
 @login_required
 def inbox(request):

--- a/tutor/views/main.py
+++ b/tutor/views/main.py
@@ -39,6 +39,11 @@ def tutors(request, course_id):
         "dnow": timezone.now(),
     }
 
+    context['ws_server_path'] = 'ws://{}:{}/'.format(
+        settings.CHAT_WS_SERVER_HOST,
+        settings.CHAT_WS_SERVER_PORT,
+    )
+
     return render(
         request,
         'tutor/tutors.html',


### PR DESCRIPTION
You are now able to get the online status of people when loading the tutors page:
![image](https://user-images.githubusercontent.com/7049313/28897649-81bf6f58-7796-11e7-8f1c-d5a93c5b9da5.png)
I didn't spend a lot of time on the css so maybe we can make it look better later. Also their online status will not change automatically. You need to reload the page to see if their status has changed. 

In order to get this to work you will need to do another `pip install -r requirements.txt`. I changed it so that it gets the `django-private-chat` package from my git repository at https://github.com/grantal/django-private-chat

Once I am able to make it so that the online status updates automatically, then I'll merge my changes in to the `django-private-chat` master and we can get rid of that requirement change.