### PR TITLE
Set up reed weblogin

### DIFF
--- a/paneity/reed_auth_backend.py
+++ b/paneity/reed_auth_backend.py
@@ -1,0 +1,48 @@
+import ldap3
+from django.conf import settings
+
+
+class ReedAuthBackend(object):
+    """
+    On a request, it looks for request.META['REMOTE_USER'] and then returns the
+    user associated with that username. If that user doesn't exist, it creates
+    it based on their data from reed's directory using ldap
+    """
+
+    def authenticate(self, request):
+        username = request.META.get('REMOTE_USER')
+        if username:
+            pass
+
+
+def get_or_create_from_ldap(username):
+    """
+    based on username it gets the associated user. If that user does
+    not exist, it creates it based on their ldap data
+    """
+    result = {}
+    if settings.DEBUG:
+        result = {"cn": ["Isabella F Jorissen", "ijorissen"], "eduPersonAffili"
+                  "ation": ["student"], "eduPersonEntitlement": ["cascade", "t"
+                  "hesis-vpn"], "eduPersonPrimaryAffiliation": "student", "edu"
+                  "PersonPrincipalName": "isjoriss@REED.EDU", "gecos": "Isabel"
+                  "la F Jorissen", "gidNumber": 503, "givenName": ["Isabella"],
+                  "homeDirectory": "/afs/reed.edu/user/i/s/isjoriss", "loginSh"
+                  "ell": "/bin/bash", "mail": ["isjoriss@reed.edu"], "objectCl"
+                  "ass": ["top", "inetOrgPerson", "eduPerson", "ReedCollegePer"
+                          "son", "posixAccount", "inetLocalMailRecipient"],
+                  "rcLocalHomeDirectory": "/home/isjoriss", "rcMiddleName":
+                  ["F"], "sn": ["Jorissen"], "uid": ["isjoriss"], "uidNumber":
+                  39878}
+    else:
+        server = ldap3.Server('ldap.reed.edu', port=389, get_info=ldap3.ALL)
+        con = ldap3.Connection(server, auto_bind=True)
+        query = 'uid={!s},ou=people,dc=reed,dc=edu'.format(username)
+        con.search(
+            search_base=query,
+            search_filter='(objectClass=*)',
+            search_scope=ldap3.SUBTREE,
+            attributes=ldap3.ALL_ATTRIBUTES)
+        result = con.response[0]['attributes']
+
+    return result

--- a/paneity/reed_auth_backend.py
+++ b/paneity/reed_auth_backend.py
@@ -52,7 +52,9 @@ def get_ldap_data(username):
                   ["F"], "sn": ["Jorissen"], "uid": ["isjoriss"], "uidNumber":
                   39878}
     else:
-        server = ldap3.Server('ldap.reed.edu', port=389, get_info=ldap3.ALL)
+        server = ldap3.Server(settings.LDAP_ADDRESS,
+                              port=settings.LDAP_PORT,
+                              get_info=ldap3.ALL)
         con = ldap3.Connection(server, auto_bind=True)
         query = 'uid={!s},ou=people,dc=reed,dc=edu'.format(username)
         con.search(

--- a/paneity/settings.py
+++ b/paneity/settings.py
@@ -85,6 +85,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.RemoteUserMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'djconfig.middleware.DjConfigMiddleware',
@@ -144,6 +145,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+AUTHENTICATION_BACKENDS = [
+    'paneity.reed_auth_backend.ReedAuthBackend',
+]
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/paneity/settings.py
+++ b/paneity/settings.py
@@ -29,8 +29,9 @@ ALLOWED_HOSTS = [
     'halp.reed.edu',
 ]
 
-# Login url, will need to change to kerberos eventually
+# Login url and logout url
 LOGIN_URL = "/admin/"
+LOGOUT_URL = "/admin/logout/"
 
 
 # Application definition
@@ -105,6 +106,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'djconfig.context_processors.config',
+                'tutor.context_processors.login_logout',
             ],
         },
     },

--- a/paneity/settings.py
+++ b/paneity/settings.py
@@ -217,3 +217,7 @@ HAYSTACK_CONNECTIONS = {
 # Stuff for django_private_chat
 CHAT_WS_SERVER_HOST = 'localhost'
 CHAT_WS_SERVER_PORT = 5002
+
+# ldap server for getting user info
+LDAP_ADDRESS = 'ldap.reed.edu'
+LDAP_PORT = 389

--- a/paneity/settings_prod.py
+++ b/paneity/settings_prod.py
@@ -15,3 +15,7 @@ DATABASES = {
         'NAME': 'paneity'
     }
 }
+
+# Login url and logout url
+LOGIN_URL = "https://weblogin.reed.edu/?cosign-halp"
+LOGOUT_URL = "https://weblogin.reed.edu/cgi-bin/logout.cgi"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-djconfig==0.5.3
 django-haystack==2.5.1
 django-infinite-scroll-pagination==0.2.0
 django-model-utils==3.0.0
--e git://github.com/reed-college/django-private-chat.git#egg=django-private-chat
+-e git://github.com/reed-college/django-private-chat.git@dev#egg=django-private-chat
 django-twitter-bootstrap==3.3.0
 mistune==0.7.1
 olefile==0.44
@@ -19,3 +19,4 @@ uni-slugify==0.1.4
 Unidecode==0.4.20
 websockets==3.2
 Whoosh==2.7.0
+ldap3==2.3

--- a/tutor/context_processors.py
+++ b/tutor/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def login_logout(request):
+    """
+    Adds LOGIN_URL and LOGOUT_URL from the settings to the context
+    """
+    return {"LOGIN_URL": settings.LOGIN_URL, "LOGOUT_URL": settings.LOGOUT_URL}

--- a/tutor/templates/tutor/base.html
+++ b/tutor/templates/tutor/base.html
@@ -47,7 +47,7 @@ Paneity | {% block title %}{% endblock %}
                     <a href="{% url "tutor:about" %}">About Us</a>
                 </div>
                 <!-- This button says 'login' if the user isn't logged in and it displays "logout" if the user is logged in. -->
-                <h6 class="login_logout">{% if user.username %}<a class="myButton" href= "{% url "admin:logout"%}">LOG OUT</a>{% else %}<a class="myButton" href="{% url "admin:index" %}">LOG IN</a>{% endif%}</h6>
+                <h6 class="login_logout">{% if user.username %}<a class="myButton" href= "{{ LOGOUT_URL }}">LOG OUT</a>{% else %}<a class="myButton" href="{{LOGIN_URL}}">LOG IN</a>{% endif%}</h6>
 
             </div>
         </div>

--- a/tutor/tests/test_views.py
+++ b/tutor/tests/test_views.py
@@ -3,15 +3,18 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 import tutor.models as models
 
+
 class IndexTestCase(TestCase):
     """
     Tests for the index view
     """
+
     def test_index_doesnt_error(self):
         response = self.client.get(reverse('tutor:index'))
         # Assert that its not an error code
         self.assertTrue(response.status_code < 400)
         self.assertTrue(response.status_code >= 200)
+
 
 class TutorTestCase(TestCase):
     """
@@ -38,10 +41,12 @@ class TutorTestCase(TestCase):
         self.assertTrue(response.status_code < 400)
         self.assertTrue(response.status_code >= 200)
 
+
 class DialogsTestCase(TestCase):
     """
     Tests for the dialogs view of django-private-chat
     """
+
     def setUp(self):
         jim = User.objects.create_user("jim", password="baz")
         jim.save()
@@ -61,6 +66,7 @@ class DialogsTestCase(TestCase):
         self.assertTrue(response.status_code < 400)
         self.assertTrue(response.status_code >= 200)
 
+
 class InboxTestCase(TestCase):
 
     def test_redirects_if_not_logged_in(self):
@@ -75,10 +81,12 @@ class InboxTestCase(TestCase):
         Makes sure that non-tutors can login
         """
         bob = User.objects.create_user("bob", password="bar")
+        bob.first_name = "Bob"
+        bob.last_name = "Jones"
+        bob.email = "bob@example.com"
         bob.save()
         self.client.login(username="bob", password="bar")
-        # bob doesn't have the right permissions
-        response = self.client.get(reverse('tutor:inbox'))
+        response = self.client.get(reverse('tutor:inbox'), REMOTE_USER="bob")
         self.assertEqual(response.status_code, 200)
         bob.delete()
 
@@ -88,10 +96,14 @@ class InboxTestCase(TestCase):
         you can access the page
         """
         johnny = User.objects.create_user("johnny", password="foo")
+        johnny.first_name = "Johnny"
+        johnny.last_name = "Wiseau"
+        johnny.email = "johnny@example.com"
         johnny.save()
         models.Student.objects.create(user=johnny)
         self.client.login(username="johnny", password="foo")
-        response = self.client.get(reverse('tutor:inbox'))
+        response = self.client.get(reverse('tutor:inbox'),
+                                   REMOTE_USER="johnny")
         self.assertEqual(response.status_code, 200)
         johnny.delete()
 
@@ -100,14 +112,16 @@ class InboxTestCase(TestCase):
         Tutors should be able to access the page
         """
         mark = User.objects.create_user("mark", password="ohhai")
+        mark.first_name = "Mark"
+        mark.last_name = "Sestero"
+        mark.email = "mark@example.com"
         mark.save()
         stu = models.Student.objects.create(user=mark)
         stu.tutor = True
         stu.save()
         self.client.login(username="mark", password="ohhai")
-        response = self.client.get(reverse('tutor:inbox'))
-        self.assertTrue(response.status_code < 400)
-        self.assertTrue(response.status_code >= 200)
+        response = self.client.get(reverse('tutor:inbox'), REMOTE_USER="mark")
+        self.assertTrue(response.status_code == 200)
         mark.delete()
 
     def test_superuser_can_access_page(self):
@@ -116,9 +130,11 @@ class InboxTestCase(TestCase):
         """
         lisa = User.objects.create_user("lisa", password="tear")
         lisa.is_superuser = True
+        lisa.first_name = "Lisa"
+        lisa.last_name = "MeApart"
+        lisa.email = "lisa@example.com"
         lisa.save()
         self.client.login(username="lisa", password="tear")
-        response = self.client.get(reverse('tutor:inbox'))
-        self.assertTrue(response.status_code < 400)
-        self.assertTrue(response.status_code >= 200)
+        response = self.client.get(reverse('tutor:inbox'), REMOTE_USER="lisa")
+        self.assertTrue(response.status_code == 200)
         lisa.delete()

--- a/tutor/util.py
+++ b/tutor/util.py
@@ -3,7 +3,31 @@ place for functions that will be used in other files
 """
 import random
 import string
+import ldap3
+from django.conf import settings
 
 
 def random_string(n):
     return ''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=n))
+
+
+def get_or_create(username):
+    """
+    based on username it gets the associated user. If that user does
+    not exist, it creates it based on their ldap data
+    """
+    result = {}
+    if settings.DEBUG:
+        result = {"cn": ["Isabella F Jorissen","ijorissen"],"eduPersonAffiliation": ["student"],"eduPersonEntitlement": ["cascade","thesis-vpn"],"eduPersonPrimaryAffiliation": "student","eduPersonPrincipalName": "isjoriss@REED.EDU","gecos": "Isabella F Jorissen","gidNumber": 503,"givenName": ["Isabella"],"homeDirectory": "/afs/reed.edu/user/i/s/isjoriss","loginShell": "/bin/bash","mail": ["isjoriss@reed.edu"],"objectClass": ["top","inetOrgPerson","eduPerson","ReedCollegePerson","posixAccount","inetLocalMailRecipient"],"rcLocalHomeDirectory": "/home/isjoriss","rcMiddleName": ["F"],"sn": ["Jorissen"],"uid": ["isjoriss"],"uidNumber": 39878}
+    else:
+        server = ldap3.Server('ldap.reed.edu', port=389, get_info=ldap3.ALL)
+        con = ldap3.Connection(server, auto_bind=True)
+        query = 'uid={!s},ou=people,dc=reed,dc=edu'.format(username)
+        con.search(
+            search_base=query,
+            search_filter='(objectClass=*)',
+            search_scope=ldap3.SUBTREE,
+            attributes=ldap3.ALL_ATTRIBUTES)
+        result = con.response[0]['attributes']
+
+    return result

--- a/tutor/util.py
+++ b/tutor/util.py
@@ -3,31 +3,7 @@ place for functions that will be used in other files
 """
 import random
 import string
-import ldap3
-from django.conf import settings
 
 
 def random_string(n):
     return ''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=n))
-
-
-def get_or_create(username):
-    """
-    based on username it gets the associated user. If that user does
-    not exist, it creates it based on their ldap data
-    """
-    result = {}
-    if settings.DEBUG:
-        result = {"cn": ["Isabella F Jorissen","ijorissen"],"eduPersonAffiliation": ["student"],"eduPersonEntitlement": ["cascade","thesis-vpn"],"eduPersonPrimaryAffiliation": "student","eduPersonPrincipalName": "isjoriss@REED.EDU","gecos": "Isabella F Jorissen","gidNumber": 503,"givenName": ["Isabella"],"homeDirectory": "/afs/reed.edu/user/i/s/isjoriss","loginShell": "/bin/bash","mail": ["isjoriss@reed.edu"],"objectClass": ["top","inetOrgPerson","eduPerson","ReedCollegePerson","posixAccount","inetLocalMailRecipient"],"rcLocalHomeDirectory": "/home/isjoriss","rcMiddleName": ["F"],"sn": ["Jorissen"],"uid": ["isjoriss"],"uidNumber": 39878}
-    else:
-        server = ldap3.Server('ldap.reed.edu', port=389, get_info=ldap3.ALL)
-        con = ldap3.Connection(server, auto_bind=True)
-        query = 'uid={!s},ou=people,dc=reed,dc=edu'.format(username)
-        con.search(
-            search_base=query,
-            search_filter='(objectClass=*)',
-            search_scope=ldap3.SUBTREE,
-            attributes=ldap3.ALL_ATTRIBUTES)
-        result = con.response[0]['attributes']
-
-    return result


### PR DESCRIPTION
I made it so that using reed weblogin will sign you in to the site (probably). Since I'm off-campus I can't test it in prod right now, but it should work. For local dev, THE ADMIN SITE LOGIN WILL NO LONGER WORK. If you want to log in as someone, type `export REMOTE_USER=username` into your terminal before calling `python manage.py runserver`. If this becomes an issue, I can add admin site logins back in. 
Closes #107 and #239 